### PR TITLE
Add generated docs for AuthConfig type

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,7 +19,7 @@ builds:
       post:
         # This will check plugin compatibility against latest version of Packer
         - cmd: |
-            go install github.com/hashicorp/packer/cmd/packer-plugins-check@v1.7.2 &&
+            go install github.com/hashicorp/packer/cmd/packer-plugins-check@latest &&
             packer-plugins-check -load={{ .Name }}
           dir: "{{ dir .Path}}"
     flags:

--- a/builder/order/config.hcl2spec.go
+++ b/builder/order/config.hcl2spec.go
@@ -45,8 +45,8 @@ type FlatConfig struct {
 	PackerOnError       *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
 	PackerUserVars      map[string]string `mapstructure:"packer_user_variables" cty:"packer_user_variables" hcl:"packer_user_variables"`
 	PackerSensitiveVars []string          `mapstructure:"packer_sensitive_variables" cty:"packer_sensitive_variables" hcl:"packer_sensitive_variables"`
-	Username            *string           `mapstructure:"username" cty:"username" hcl:"username"`
-	Password            *string           `mapstructure:"password" cty:"password" hcl:"password"`
+	Username            *string           `mapstructure:"username" required:"true" cty:"username" hcl:"username"`
+	Password            *string           `mapstructure:"password" required:"true" cty:"password" hcl:"password"`
 	Host                *string           `mapstructure:"host" cty:"host" hcl:"host"`
 	Item                []FlatOrderItem   `mapstructure:"item" required:"true" cty:"item" hcl:"item"`
 }

--- a/common/auth.go
+++ b/common/auth.go
@@ -1,3 +1,4 @@
+//go:generate packer-sdc struct-markdown
 //go:generate packer-sdc mapstructure-to-hcl2 -type AuthConfig
 
 package common
@@ -5,9 +6,12 @@ package common
 import "github.com/hashicorp-demoapp/hashicups-client-go"
 
 type AuthConfig struct {
-	Username string `mapstructure:"username"`
-	Password string `mapstructure:"password"`
-	Host     string `mapstructure:"host"`
+	// The username signed up to the Product API.
+	Username string `mapstructure:"username" required:"true"`
+	// The password for the username signed up to the Product API.
+	Password string `mapstructure:"password" required:"true"`
+	// The Product API host URL. Defaults to `localhost:19090`
+	Host string `mapstructure:"host"`
 }
 
 func (c *AuthConfig) CreateClient() (*hashicups.Client, error) {

--- a/common/auth.hcl2spec.go
+++ b/common/auth.hcl2spec.go
@@ -10,8 +10,8 @@ import (
 // FlatAuthConfig is an auto-generated flat version of AuthConfig.
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatAuthConfig struct {
-	Username *string `mapstructure:"username" cty:"username" hcl:"username"`
-	Password *string `mapstructure:"password" cty:"password" hcl:"password"`
+	Username *string `mapstructure:"username" required:"true" cty:"username" hcl:"username"`
+	Password *string `mapstructure:"password" required:"true" cty:"password" hcl:"password"`
 	Host     *string `mapstructure:"host" cty:"host" hcl:"host"`
 }
 

--- a/datasource/coffees/data.hcl2spec.go
+++ b/datasource/coffees/data.hcl2spec.go
@@ -10,8 +10,8 @@ import (
 // FlatConfig is an auto-generated flat version of Config.
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatConfig struct {
-	Username *string `mapstructure:"username" cty:"username" hcl:"username"`
-	Password *string `mapstructure:"password" cty:"password" hcl:"password"`
+	Username *string `mapstructure:"username" required:"true" cty:"username" hcl:"username"`
+	Password *string `mapstructure:"password" required:"true" cty:"password" hcl:"password"`
 	Host     *string `mapstructure:"host" cty:"host" hcl:"host"`
 }
 

--- a/datasource/ingredients/data.hcl2spec.go
+++ b/datasource/ingredients/data.hcl2spec.go
@@ -10,8 +10,8 @@ import (
 // FlatConfig is an auto-generated flat version of Config.
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatConfig struct {
-	Username *string `mapstructure:"username" cty:"username" hcl:"username"`
-	Password *string `mapstructure:"password" cty:"password" hcl:"password"`
+	Username *string `mapstructure:"username" required:"true" cty:"username" hcl:"username"`
+	Password *string `mapstructure:"password" required:"true" cty:"password" hcl:"password"`
 	Host     *string `mapstructure:"host" cty:"host" hcl:"host"`
 	Coffee   *string `mapstructure:"coffee" required:"true" cty:"coffee" hcl:"coffee"`
 }

--- a/docs-partials/common/AuthConfig-not-required.mdx
+++ b/docs-partials/common/AuthConfig-not-required.mdx
@@ -1,0 +1,5 @@
+<!-- Code generated from the comments of the AuthConfig struct in common/auth.go; DO NOT EDIT MANUALLY -->
+
+- `host` (string) - The Product API host URL. Defaults to `localhost:19090`
+
+<!-- End of code generated from the comments of the AuthConfig struct in common/auth.go; -->

--- a/docs-partials/common/AuthConfig-required.mdx
+++ b/docs-partials/common/AuthConfig-required.mdx
@@ -1,0 +1,7 @@
+<!-- Code generated from the comments of the AuthConfig struct in common/auth.go; DO NOT EDIT MANUALLY -->
+
+- `username` (string) - The username signed up to the Product API.
+
+- `password` (string) - The password for the username signed up to the Product API.
+
+<!-- End of code generated from the comments of the AuthConfig struct in common/auth.go; -->

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,27 +1,27 @@
 # HashiCups Plugin
 
-The Hashicups plugin is part of the [Packer](https://learn.hashicorp.com/packer) Learn collection. 
-The plugin interacts with the [HashiCorp Demo App API](https://github.com/hashicorp-demoapp/product-api-go) called HashiCups. 
+The Hashicups plugin is part of the [Packer](https://learn.hashicorp.com/packer) Learn collection.
+The plugin interacts with the [HashiCorp Demo App API](https://github.com/hashicorp-demoapp/product-api-go) called HashiCups.
 The component of this plugin are:
 
-- [Order builder](/docs/builders/order.mdx) - The order builder is used to create custom HashiCups order.
+- [Order builder](builders/order.mdx) - The order builder is used to create custom HashiCups order.
 
-- [Toppings provisiner](/docs/provisioners/toppings.mdx) - The toppings provisioner is used to add toppings to your order coffee(s).
+- [Toppings provisiner](provisioners/toppings.mdx) - The toppings provisioner is used to add toppings to your order coffee(s).
 
-- [Receipt post-processor](/docs/post-processors/receipt.mdx) - The receipt post-processor is used to
+- [Receipt post-processor](post-processors/receipt.mdx) - The receipt post-processor is used to
   print the receipt of your order.
 
-- [Coffees data source](/docs/datasources/coffees.mdx) - The coffees data source is used to
+- [Coffees data source](datasources/coffees.mdx) - The coffees data source is used to
   fetch all the coffees ids existent in the Hashicups menu.
-  
-- [Ingredients data source](/docs/datasources/ingredients.mdx) - The ingredients data source is used to
+
+- [Ingredients data source](datasources/ingredients.mdx) - The ingredients data source is used to
   fetch the ingredients ids for an existent coffee in the Hashicups menu.
 
 ## The HashiCups menu and orders
 
-Get the available coffees: 
+Get the available coffees:
 ```shell
-$ curl -v localhost:19090/coffees | jq 
+$ curl -v localhost:19090/coffees | jq
 ```
 
 The following api call requires authorization.

--- a/docs/builders/index.mdx
+++ b/docs/builders/index.mdx
@@ -18,7 +18,7 @@ Then, run [`packer init`](/docs/commands/init).
 packer {
   required_plugins {
     hashicups = {
-      version = ">= 1.0.0"
+      version = ">= 1.0.1"
       source = "github.com/hashicorp/hashicups"
     }
   }

--- a/docs/builders/order.mdx
+++ b/docs/builders/order.mdx
@@ -15,13 +15,13 @@ understand better how it works.
 
 ### Required
 
-- `username` (string) - The username signed up to the Product API.
-- `password` (string) - The password signed up to the Product API.
+@include 'common/AuthConfig-required.mdx'
+
 - `item` ([]OrderItem) - An item you would like to order. See the [order item configuration](#order-item-configuration).
 
 ### Optional
 
-- `host` (string) - The Product API host. Defaults to `localhost:19090`
+@include 'common/AuthConfig-not-required.mdx'
 
 ## Order item configuration
 

--- a/docs/datasources/coffees.mdx
+++ b/docs/datasources/coffees.mdx
@@ -14,12 +14,11 @@ The coffees data source is used to fetch all the coffees ids existent in the Has
 
 ### Required
 
-- `username` (string) - The username signed up to the Product API.
-- `password` (string) - The password signed up to the Product API.
+@include 'common/AuthConfig-required.mdx'
 
 ### Optional
 
-- `host` (string) - The Product API host. Defaults to `localhost:19090`
+@include 'common/AuthConfig-not-required.mdx'
 
 ### OutPut
 

--- a/docs/datasources/index.mdx
+++ b/docs/datasources/index.mdx
@@ -22,7 +22,7 @@ Then, run [`packer init`](/docs/commands/init).
 packer {
   required_plugins {
     hashicups = {
-      version = ">= 1.0.0"
+      version = ">= 1.0.1"
       source = "github.com/hashicorp/hashicups"
     }
   }

--- a/docs/datasources/ingredients.mdx
+++ b/docs/datasources/ingredients.mdx
@@ -14,13 +14,13 @@ The ingredients data source is used to fetch the ingredients ids for an existent
 
 ### Required
 
-- `username` (string) - The username signed up to the Product API.
-- `password` (string) - The password signed up to the Product API.
+@include 'common/AuthConfig-required.mdx'
+
 - `coffee` (string) - The coffee id you would like to get the ingredient from. The ID should exist in the Hashicups menu.
 
 ### Optional
 
-- `host` (string) - The Product API host. Defaults to `localhost:19090`
+@include 'common/AuthConfig-not-required.mdx'
 
 ### OutPut
 

--- a/docs/post-processors/index.mdx
+++ b/docs/post-processors/index.mdx
@@ -19,7 +19,7 @@ Then, run [`packer init`](/docs/commands/init).
 packer {
   required_plugins {
     hashicups = {
-      version = ">= 1.0.0"
+      version = ">= 1.0.1"
       source = "github.com/hashicorp/hashicups"
     }
   }

--- a/docs/provisioners/index.mdx
+++ b/docs/provisioners/index.mdx
@@ -18,7 +18,7 @@ Then, run [`packer init`](/docs/commands/init).
 packer {
   required_plugins {
     hashicups = {
-      version = ">= 1.0.0"
+      version = ">= 1.0.1"
       source = "github.com/hashicorp/hashicups"
     }
   }


### PR DESCRIPTION
Please review/approve but do not merge as I will be merging as part of my demo. 

This change is being made to demo the use of the packer-sdc command for documentation generation and publishing. 
A release will then be cut with the updated docs to show case the flow of remote-plugin docs rendering on Packer.io. 


* docs/README.md: Fix relative links to plugin docs
