### PR TITLE
bump go 1.16 to 1.19

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,12 @@
 module packer-plugin-hashicups
 
-go 1.16
+go 1.19
 
 require (
 	github.com/hashicorp-demoapp/hashicups-client-go v0.0.0-20210316102605-c2dc0b667c4e
 	github.com/hashicorp/hcl/v2 v2.13.0
 	github.com/hashicorp/packer-plugin-sdk v0.4.0
-	github.com/jung-kurt/gofpdf v1.16.2
+	github.com/jung-kurt/gofpdf v1.19.2
 	github.com/mitchellh/mapstructure v1.4.1
 	github.com/zclconf/go-cty v1.10.0
 )


### PR DESCRIPTION
- workflows: remove go-test.yml
- go.mod: bump go version from 1.16 to 1.19
